### PR TITLE
Updated JavaTips CTRL+Delete in dev 

### DIFF
--- a/JavaTips
+++ b/JavaTips
@@ -17,3 +17,4 @@ long=population of world
 crtl+D - delets the entire line )like (shift+home & backspace)
 JVM,JRE,JDK
 CTRl+D for full line delete
+CRTL+delete will delete the word which is after the cursor


### PR DESCRIPTION
I have added a new tip to delete the word which is after the cursor, this has been tested and working fine in dev branch. Please pull this tip to the main branch